### PR TITLE
Inclusivity patch

### DIFF
--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -2,3 +2,5 @@
   location: http://osm.org/go/0MbFY1uV4?node=3230907861
 - name: Mozilla Paris
   location: http://osm.org/go/0BPIiU9l1?node=2883451098
+- name: Rust Cologne
+  location:

--- a/_site/index.html
+++ b/_site/index.html
@@ -48,15 +48,21 @@
         <ul>
         
           <li>
-            <a href="http://osm.org/go/0MbFY1uV4?node=3230907861">
+             <a href="http://osm.org/go/0MbFY1uV4?node=3230907861">
               Mozilla Berlin
             </a>
           </li>
         
           <li>
-            <a href="http://osm.org/go/0BPIiU9l1?node=2883451098">
+             <a href="http://osm.org/go/0BPIiU9l1?node=2883451098">
               Mozilla Paris
             </a>
+          </li>
+        
+          <li>
+             
+              Rust Cologne
+            
           </li>
         
         </ul>
@@ -89,6 +95,9 @@
         </ul>
         </p>
 
+        <h2>Code of Conduct</h2>
+
+        <p>The <a href="https://www.rust-lang.org/en-US/conduct.html">Rust Code of Conduct</a> applies to this event.</p>
       </section>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -37,6 +37,8 @@ title: Blogging Like a Hacker
 
         <p>The event is open to beginners interested in learning Rust while building a small project.</p>
 
+        <p>The Rust community is an inclusive community and people from marginalised groups are specifically welcome.</p>
+
         <p>For that, we are searching:
           <ul>
             <li>People that want to provide a venue at their location for hackers to meet - face to face is always great</li>

--- a/index.html
+++ b/index.html
@@ -37,9 +37,10 @@ title: Blogging Like a Hacker
 
         <p>The event is open to beginners interested in learning Rust while building a small project.</p>
 
-        <p>The Rust community is an inclusive community and people from marginalised groups are specifically welcome.</p>
+        <p>The Rust community aims to be an inclusive community. People from traditionally underrepresented groups in tech are specifically welcome and invited to join.
+        This includes, but is not limited to: non-men, people of color, disabled people, and LGBTQIA+ people.</p>
 
-        <p>For that, we are searching:
+        <p>For novemb.rs, we are searching:
           <ul>
             <li>People that want to provide a venue at their location for hackers to meet - face to face is always great</li>
             <li>People providing virtual meeting grounds for those not able to attend one of the physical meetings</li>

--- a/index.html
+++ b/index.html
@@ -51,9 +51,9 @@ title: Blogging Like a Hacker
         <ul>
         {% for location in site.data.locations %}
           <li>
-            <a href="{{ location.location }}">
+            {% if location.location %}<a href="{{ location.location }}">{% endif %}
               {{ location.name }}
-            </a>
+            {% if location.location %}</a>{% endif %}
           </li>
         {% endfor %}
         </ul>
@@ -86,6 +86,9 @@ title: Blogging Like a Hacker
         </ul>
         </p>
 
+        <h2>Code of Conduct</h2>
+
+        <p>The <a href="https://www.rust-lang.org/en-US/conduct.html">Rust Code of Conduct</a> applies to this event.</p>
       </section>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -35,6 +35,8 @@ title: Blogging Like a Hacker
 
         <p>The goal is to start new projects, work on their current ones or get involved in new ones. The event is open to anyone, but we can provide most support to people UTC -1 to UTC +4, the European and African continent.</p>
 
+        <p>The event is open to beginners interested in learning Rust while building a small project.</p>
+
         <p>For that, we are searching:
           <ul>
             <li>People that want to provide a venue at their location for hackers to meet - face to face is always great</li>


### PR DESCRIPTION
Added inclusivity statement, stating examples for underrepresented groups.

As suggested [here](https://twitter.com/malpinder/status/789941987671703552), let's write 'non-men' instead of 'women and nonbinary people', as it seems a more appropriate term.
