### PR TITLE
Include more information per event

### DIFF
--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -4,6 +4,8 @@
   location: http://osm.org/go/0BPIiU9l1?node=2883451098
 - name: Rust Cologne
   location: http://osm.org/go/0GC9nD1u_?node=1446603282
+  more: "Open Saturday/Sunday 12pm-10pm"
+  event_link: https://www.meetup.com/RustCologne/events/235374218/
 - name: Progressbar Bratislava
   location: https://www.progressbar.sk/en/calendar/novemb-rs
 - name: Rust Vilnius

--- a/index.html
+++ b/index.html
@@ -63,10 +63,18 @@ title: novemb.rs Code Sprint
             {% if location.location %}<a href="{{ location.location }}">{% endif %}
               {{ location.name }}
             {% if location.location %}</a>{% endif %}
+          {% if location.more %}
+          <br>
+          <span>
+            {{ location.more }}{% if location.event_link %},
+            <a href="{{ location.event_link }}">Event</a>
+            {% endif %}
+          </span>
+          {% endif %}
           </li>
         {% endfor %}
         </ul>
-		
+
         <h2>Online locations</h2>
         <p>If you would like to provide an additional online meeting ground, please
           file an issue <a href="https://github.com/rust-community/novemb.rs/issues/new?title=Online%20venue">here</a>.</p>


### PR DESCRIPTION
so it might make sense to include the most important info per location right on the main page.
Things like times and any special information or a link besides the location (which for some now points to the event page, for others to a map).